### PR TITLE
Remove dummy events; keep calendar; add TODOs

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from 'next'
-import Image from 'next/image'
 import Link from 'next/link'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { CalendarIcon, MapPinIcon, ClockIcon, ArrowRight, ExternalLink } from 'lucide-react'
+// import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ArrowRight, ExternalLink } from 'lucide-react'
 
 export const metadata: Metadata = {
   title: 'Events | OPEN Silicon Valley',
@@ -12,29 +10,17 @@ export const metadata: Metadata = {
 }
 
 export default function EventsPage() {
+  /*
+  // Event categories (temporarily disabled)
   const eventCategories = [
-    {
-      id: 'all',
-      label: 'All Events',
-    },
-    {
-      id: 'conferences',
-      label: 'Conferences',
-    },
-    {
-      id: 'seminars',
-      label: 'Seminars',
-    },
-    {
-      id: 'webinars',
-      label: 'Webinars',
-    },
-    {
-      id: 'networking',
-      label: 'Networking',
-    },
+    { id: 'all', label: 'All Events' },
+    { id: 'conferences', label: 'Conferences' },
+    { id: 'seminars', label: 'Seminars' },
+    { id: 'webinars', label: 'Webinars' },
+    { id: 'networking', label: 'Networking' },
   ]
 
+  // Dummy events (temporarily disabled)
   const events = [
     {
       id: 1,
@@ -101,6 +87,7 @@ export default function EventsPage() {
       image: '/placeholder.svg?height=300&width=500&text=Global+Summit',
     },
   ]
+  */
 
   return (
     <div className="bg-white">
@@ -127,125 +114,79 @@ export default function EventsPage() {
         </div>
       </section>
 
-      {/* Featured Event */}
+      {/* Featured/Event listings hidden for now */}
+      {/**
+       * Previously included a featured event hero and tabbed event listings based on dummy data.
+       * Keeping the original JSX commented out for later reuse.
+       */}
+      {/**
       <section className="py-16">
-        <div className="container mx-auto px-4">
-          <div className="max-w-6xl mx-auto">
-            <div className="bg-primary/5 rounded-2xl overflow-hidden">
-              <div className="flex flex-col md:flex-row">
-                <div className="md:w-1/2 relative">
-                  <Image
-                    src="/placeholder.svg?height=600&width=800&text=Annual+Conference"
-                    alt="Annual Entrepreneurship Conference"
-                    width={800}
-                    height={600}
-                    className="w-full h-full object-cover"
-                  />
-                  <div className="absolute top-4 left-4 bg-primary text-white px-3 py-1 rounded-full text-sm font-medium">
-                    Featured Event
-                  </div>
-                </div>
-                <div className="md:w-1/2 p-8 md:p-12 flex flex-col justify-center">
-                  <h2 className="text-3xl font-bold mb-4">Annual Entrepreneurship Conference</h2>
-                  <div className="space-y-4 mb-6">
-                    <div className="flex items-center gap-2">
-                      <CalendarIcon className="h-5 w-5 text-primary" />
-                      <span>September 15, 2025</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <ClockIcon className="h-5 w-5 text-primary" />
-                      <span>9:00 AM - 5:00 PM</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <MapPinIcon className="h-5 w-5 text-primary" />
-                      <span>San Jose Convention Center</span>
-                    </div>
-                  </div>
-                  <p className="text-gray-600 mb-8">
-                    Join us for our annual flagship event bringing together entrepreneurs,
-                    investors, and industry leaders. The conference features keynote speeches, panel
-                    discussions, networking opportunities, and a startup showcase.
-                  </p>
-                  <div className="flex flex-wrap gap-4">
-                    <Button className="rounded-full">Register Now</Button>
-                    <Button variant="outline" className="rounded-full">
-                      Learn More
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        ... featured event block ...
       </section>
 
-      {/* Event Tabs */}
       <section className="py-16">
-        <div className="container mx-auto px-4">
-          <div className="max-w-6xl mx-auto">
-            <Tabs defaultValue="all" className="mb-12">
-              <TabsList className="mb-8 flex flex-wrap justify-center">
-                {eventCategories.map((category) => (
-                  <TabsTrigger key={category.id} value={category.id}>
-                    {category.label}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+        <Tabs defaultValue="all" className="mb-12">
+          <TabsList className="mb-8 flex flex-wrap justify-center">
+            {eventCategories.map((category) => (
+              <TabsTrigger key={category.id} value={category.id}>
+                {category.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
 
-              {eventCategories.map((category) => (
-                <TabsContent key={category.id} value={category.id}>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {events
-                      .filter((event) => category.id === 'all' || event.category === category.id)
-                      .map((event) => (
-                        <Card
-                          key={event.id}
-                          className="border-gray-100 shadow-xs hover:shadow-md transition-all duration-300 overflow-hidden"
-                        >
-                          <div className="aspect-video relative">
-                            <Image
-                              src={event.image || '/placeholder.svg'}
-                              alt={event.title}
-                              fill
-                              className="object-cover"
-                              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                            />
+          {eventCategories.map((category) => (
+            <TabsContent key={category.id} value={category.id}>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {events
+                  .filter((event) => category.id === 'all' || event.category === category.id)
+                  .map((event) => (
+                    <Card
+                      key={event.id}
+                      className="border-gray-100 shadow-xs hover:shadow-md transition-all duration-300 overflow-hidden"
+                    >
+                      <div className="aspect-video relative">
+                        <Image
+                          src={event.image || '/placeholder.svg'}
+                          alt={event.title}
+                          fill
+                          className="object-cover"
+                          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                        />
+                      </div>
+                      <CardHeader>
+                        <div className="inline-block px-3 py-1 bg-primary/10 rounded-full text-primary text-xs font-medium mb-2">
+                          {category.id === 'all' ? event.category : category.label}
+                        </div>
+                        <CardTitle>{event.title}</CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <div className="space-y-3 mb-4">
+                          <div className="flex items-center gap-2 text-sm">
+                            <CalendarIcon className="h-4 w-4 text-primary" />
+                            <span>{event.date}</span>
                           </div>
-                          <CardHeader>
-                            <div className="inline-block px-3 py-1 bg-primary/10 rounded-full text-primary text-xs font-medium mb-2">
-                              {category.id === 'all' ? event.category : category.label}
-                            </div>
-                            <CardTitle>{event.title}</CardTitle>
-                          </CardHeader>
-                          <CardContent>
-                            <div className="space-y-3 mb-4">
-                              <div className="flex items-center gap-2 text-sm">
-                                <CalendarIcon className="h-4 w-4 text-primary" />
-                                <span>{event.date}</span>
-                              </div>
-                              <div className="flex items-center gap-2 text-sm">
-                                <ClockIcon className="h-4 w-4 text-primary" />
-                                <span>{event.time}</span>
-                              </div>
-                              <div className="flex items-center gap-2 text-sm">
-                                <MapPinIcon className="h-4 w-4 text-primary" />
-                                <span>{event.location}</span>
-                              </div>
-                            </div>
-                            <p className="text-gray-600">{event.description}</p>
-                          </CardContent>
-                          <CardFooter>
-                            <Button className="w-full">Register</Button>
-                          </CardFooter>
-                        </Card>
-                      ))}
-                  </div>
-                </TabsContent>
-              ))}
-            </Tabs>
-          </div>
-        </div>
+                          <div className="flex items-center gap-2 text-sm">
+                            <ClockIcon className="h-4 w-4 text-primary" />
+                            <span>{event.time}</span>
+                          </div>
+                          <div className="flex items-center gap-2 text-sm">
+                            <MapPinIcon className="h-4 w-4 text-primary" />
+                            <span>{event.location}</span>
+                          </div>
+                        </div>
+                        <p className="text-gray-600">{event.description}</p>
+                      </CardContent>
+                      <CardFooter>
+                        <Button className="w-full">Register</Button>
+                      </CardFooter>
+                    </Card>
+                  ))}
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
       </section>
+      */}
 
       {/* Calendar Section */}
       <section className="py-16 bg-gray-50">
@@ -287,86 +228,20 @@ export default function EventsPage() {
         </div>
       </section>
 
-      {/* Events Gallery */}
+      {/* Events Gallery hidden for now */}
+      {/**
+       * Previously showed a grid of placeholder gallery images with a CTA to the full gallery page.
+       * Keeping commented for later reuse.
+       */}
+      {/**
       <section className="py-16">
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Events Gallery</h2>
-              <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-                Check out photos and videos from our past events. Get a glimpse of the OPEN Silicon
-                Valley community in action.
-              </p>
-            </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-              <div className="col-span-2 row-span-2">
-                <div className="rounded-xl overflow-hidden h-full">
-                  <Image
-                    src="/placeholder.svg?height=600&width=800&text=Annual+Forum"
-                    alt="Annual Forum"
-                    width={800}
-                    height={600}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-              </div>
-              <div>
-                <div className="rounded-xl overflow-hidden h-full">
-                  <Image
-                    src="/placeholder.svg?height=300&width=400&text=Networking"
-                    alt="Networking Event"
-                    width={400}
-                    height={300}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-              </div>
-              <div>
-                <div className="rounded-xl overflow-hidden h-full">
-                  <Image
-                    src="/placeholder.svg?height=300&width=400&text=Workshop"
-                    alt="Workshop"
-                    width={400}
-                    height={300}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-              </div>
-              <div>
-                <div className="rounded-xl overflow-hidden h-full">
-                  <Image
-                    src="/placeholder.svg?height=300&width=400&text=Panel"
-                    alt="Panel Discussion"
-                    width={400}
-                    height={300}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-              </div>
-              <div>
-                <div className="rounded-xl overflow-hidden h-full">
-                  <Image
-                    src="/placeholder.svg?height=300&width=400&text=Pitch"
-                    alt="Startup Pitch"
-                    width={400}
-                    height={300}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div className="text-center">
-              <Button asChild variant="outline" className="rounded-full">
-                <Link href="/events-directory/events-gallery" className="flex items-center gap-2">
-                  View Full Gallery <ArrowRight className="h-4 w-4" />
-                </Link>
-              </Button>
-            </div>
+            ... gallery grid and CTA ...
           </div>
         </div>
       </section>
+      */}
 
       {/* Host an Event */}
       <section className="py-16 bg-primary/5">

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -10,6 +10,8 @@ export const metadata: Metadata = {
 }
 
 export default function EventsPage() {
+  // TODO(events): Decide on source of truth (Google Calendar sync, CMS, or Wild Apricot)
+  // and re-enable the featured block + tabbed listing below.
   /*
   // Event categories (temporarily disabled)
   const eventCategories = [
@@ -194,6 +196,7 @@ export default function EventsPage() {
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
               <h2 className="text-3xl font-bold mb-4">Events Calendar</h2>
+              {/* TODO(copy): Replace with dynamic/conditional copy once events are wired. */}
               <p className="text-lg text-gray-600 max-w-2xl mx-auto">
                 Stay updated with all our upcoming events. Subscribe to our calendar to never miss
                 an opportunity to connect and grow.

--- a/components/events-section.tsx
+++ b/components/events-section.tsx
@@ -1,9 +1,8 @@
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
-import { CalendarIcon, MapPinIcon, ClockIcon } from 'lucide-react'
 
 export default function EventsSection() {
+  /*
   const upcomingEvents = [
     {
       id: 1,
@@ -27,7 +26,7 @@ export default function EventsSection() {
       location: 'OpenSV Hub, Palo Alto',
     },
   ]
-
+  */
   return (
     <div className="container mx-auto px-4">
       <div className="text-center mb-12">
@@ -38,6 +37,14 @@ export default function EventsSection() {
         </p>
       </div>
 
+      <div className="text-center text-muted-foreground">
+        Event announcements will be posted here soon. In the meantime, visit our Events page for the
+        calendar.
+      </div>
+      {/**
+       * Previously displayed dummy events grid. Keeping commented for later use.
+       */}
+      {/**
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
         {upcomingEvents.map((event) => (
           <Card key={event.id}>
@@ -68,6 +75,7 @@ export default function EventsSection() {
           </Card>
         ))}
       </div>
+      */}
 
       <div className="text-center mt-12">
         <Button asChild size="lg">

--- a/components/events-section.tsx
+++ b/components/events-section.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 
 export default function EventsSection() {
+  // TODO(events): When real events are available, re-enable the grid below and replace placeholder copy.
   /*
   const upcomingEvents = [
     {
@@ -37,6 +38,7 @@ export default function EventsSection() {
         </p>
       </div>
 
+      {/* TODO(copy): Replace with link or highlights once events are wired. */}
       <div className="text-center text-muted-foreground">
         Event announcements will be posted here soon. In the meantime, visit our Events page for the
         calendar.

--- a/components/upcoming-events.tsx
+++ b/components/upcoming-events.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 
 export default function UpcomingEvents() {
+  // TODO(events): Wire up events from a real source (Google Calendar, CMS, or Wild Apricot),
+  // then re-enable the list below.
   /*
   // Sample upcoming events (temporarily disabled)
   const upcomingEvents = [
@@ -49,6 +51,7 @@ export default function UpcomingEvents() {
         </div>
 
         <div className="max-w-5xl mx-auto">
+          {/* TODO(copy): Replace with dynamic summary once events are wired. */}
           <div className="mb-16 text-center text-gray-600">
             Event announcements will be posted here soon. In the meantime, subscribe to our calendar
             below.

--- a/components/upcoming-events.tsx
+++ b/components/upcoming-events.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
-import { Calendar, ArrowRight, Clock, MapPin } from 'lucide-react'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { ArrowRight } from 'lucide-react'
 
 export default function UpcomingEvents() {
-  // Sample upcoming events
+  /*
+  // Sample upcoming events (temporarily disabled)
   const upcomingEvents = [
     {
       id: 1,
@@ -31,7 +31,7 @@ export default function UpcomingEvents() {
       category: 'Speaker Series',
     },
   ]
-
+  */
   return (
     <section aria-labelledby="events-heading" className="py-24 bg-white">
       <div className="container mx-auto px-4">
@@ -49,6 +49,14 @@ export default function UpcomingEvents() {
         </div>
 
         <div className="max-w-5xl mx-auto">
+          <div className="mb-16 text-center text-gray-600">
+            Event announcements will be posted here soon. In the meantime, subscribe to our calendar
+            below.
+          </div>
+          {/**
+           * Previously displayed a grid of dummy upcoming events. Keeping for reference.
+           */}
+          {/**
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
             {upcomingEvents.map((event) => (
               <Card
@@ -86,6 +94,7 @@ export default function UpcomingEvents() {
               </Card>
             ))}
           </div>
+          */}
 
           <div className="bg-gray-50 rounded-2xl p-8 shadow-xs">
             <div className="text-center mb-8">

--- a/docs/operations/TODO-events.md
+++ b/docs/operations/TODO-events.md
@@ -1,0 +1,27 @@
+# Events TODOs
+
+- [ ] Decide source of truth for events
+  - [ ] Google Calendar as primary, or
+  - [ ] CMS (e.g., headless) with ICS sync, or
+  - [ ] Wild Apricot API for events
+- [ ] Implement server-side fetch for events
+  - [ ] Create `lib/events.ts` with fetch/adapters
+  - [ ] Types for `EventItem` (title, start/end, location, url, category, image)
+- [ ] Wire homepage `UpcomingEvents` to real data
+  - [ ] Replace placeholder text
+  - [ ] Re-enable cards grid
+- [ ] Wire `app/events/page.tsx`
+  - [ ] Featured event block from next upcoming
+  - [ ] Tabs/filters by category (if available)
+  - [ ] Pagination or lazy-load if many events
+- [ ] Add calendar subscription CTA (done)
+  - [x] Google Calendar embed and subscribe link
+- [ ] Accessibility and SEO
+  - [ ] `aria-label`s, headings structure
+  - [ ] Structured data (Event schema)
+- [ ] Analytics
+  - [ ] Track clicks on Register/Subscribe buttons
+- [ ] Content
+  - [ ] Replace copy placeholders flagged as TODO(copy)
+- [ ] Cleanup
+  - [ ] Remove commented dummy blocks once data is live


### PR DESCRIPTION
### Summary
- Remove hardcoded/dummy event listings
- Preserve prior UI as comments for easy restore
- Keep Google Calendar embed and subscribe CTA as source of truth
- Add TODOs and a short checklist for wiring real data

### Changes
- `components/upcoming-events.tsx`: placeholder copy; calendar kept; commented data/UI; TODOs
- `components/events-section.tsx`: placeholder + CTA; commented grid; TODOs
- `app/events/page.tsx`: hide featured + tabbed listings; keep hero and calendar; TODOs
- `docs/operations/TODO-events.md`: new events integration checklist

### Verification
- `npm run check:build` (typecheck, lint, prettier, build) all pass

### Next steps
- Choose events data source (Google Calendar, CMS, or Wild Apricot) and re-enable UI with real data
